### PR TITLE
Add github action to maintain Changelog and includes changelog skiplabel

### DIFF
--- a/.github/workflows/changelog_verifier.yml
+++ b/.github/workflows/changelog_verifier.yml
@@ -1,0 +1,19 @@
+name: "Changelog Verifier"
+on:
+  pull_request:
+    branches: [ '**', '!feature/**' ]
+    types: [opened, edited, review_requested, synchronize, reopened, ready_for_review, labeled, unlabeled]
+
+jobs:
+  # Enforces the update of a changelog file on every pull request
+  verify-changelog:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - uses: dangoslen/changelog-enforcer@v3
+        with:
+          skipLabels: "autocut, Skip-Changelog"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,25 @@
+# CHANGELOG
+
+Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+
+## [Unreleased]
+
+### 💥 Breaking Changes
+
+### Deprecations
+
+### 🛡 Security
+
+### 📈 Features/Enhancements
+
+### 🐛 Bug Fixes
+
+### 🚞 Infrastructure
+
+### 📝 Documentation
+
+### 🛠 Maintenance
+
+### 🪛 Refactoring
+
+### 🔩 Tests


### PR DESCRIPTION
Signed-off-by: manasvinibs <manasvis@amazon.com>

### Description
Add CHANGELOG.md [example](https://github.com/opensearch-project/OpenSearch-Dashboards/blob/main/CHANGELOG.md)
Add workflow for verifying CHANGELOG.md [example](https://github.com/opensearch-project/OpenSearch-Dashboards/blob/main/.github/workflows/changelog_verifier.yml)
Add labels to support CHANGELOG skipping.

### Issues Resolved
https://github.com/opensearch-project/opensearch-dashboards-sdk-js/issues/4

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
